### PR TITLE
Lines and words

### DIFF
--- a/elm.json
+++ b/elm.json
@@ -10,7 +10,7 @@
     "elm-version": "0.19.0 <= v < 0.20.0",
     "dependencies": {
         "elm/core": "1.0.0 <= v < 2.0.0",
-        "elm/html": "1.0.0 <= v < 2.0.0"
+        "elm-community/basics-extra": "4.0.0 <= v < 5.0.0"
     },
     "test-dependencies": {}
 }

--- a/src/Pretty.elm
+++ b/src/Pretty.elm
@@ -1,6 +1,7 @@
 module Pretty
     exposing
         ( Doc
+        , a
         , align
         , append
         , braces
@@ -30,7 +31,7 @@ Functions for building pieces of documents from string data.
 
 Functions for joining documents together
 
-@docs append, join
+@docs append, a, join
 
 Functions for fitting documents onto lines as space allows.
 
@@ -49,6 +50,8 @@ Functions for pretty printing documents.
 @docs pretty
 
 -}
+
+import Basics.Extra exposing (flip)
 
 
 {-| The type of documents that can be pretty printed.
@@ -145,6 +148,21 @@ nesting =
 
 
 -- Document helper functions ---------------------------------------------------
+
+
+{-| Short hand notation for append.
+Usefull when appending multiple parts together:
+
+    string "Hello"
+      |> a space
+      |> a "World"
+      |> a (char '!')
+      |> a line
+
+-}
+a : Doc -> Doc -> Doc
+a =
+    flip append
 
 
 {-| Places a document inside left and right book ends.

--- a/src/Pretty.elm
+++ b/src/Pretty.elm
@@ -7,6 +7,7 @@ module Pretty
         , braces
         , char
         , empty
+        , fold
         , group
         , hang
         , indent
@@ -34,7 +35,7 @@ Functions for building pieces of documents from string data.
 
 Functions for joining documents together
 
-@docs append, a, join, lines, softlines, words
+@docs append, a, join, lines, softlines, words, fold
 
 Functions for fitting documents onto lines as space allows.
 
@@ -239,6 +240,16 @@ See also `lines`.
 words : List Doc -> Doc
 words =
     join space
+
+
+{-| Fold a list of documents from left to right using a given function.
+
+    fold f == List.foldl f empty
+
+-}
+fold : (a -> Doc -> Doc) -> List a -> Doc
+fold f =
+    List.foldl f empty
 
 
 {-| Creates a document consisting of a single space.

--- a/src/Pretty.elm
+++ b/src/Pretty.elm
@@ -1,12 +1,24 @@
-module Pretty exposing
-    ( Doc
-    , empty, space, string, char
-    , append, join
-    , group, line, softline
-    , align, nest, hang, indent
-    , surround, parens, braces
-    , pretty
-    )
+module Pretty
+    exposing
+        ( Doc
+        , align
+        , append
+        , braces
+        , char
+        , empty
+        , group
+        , hang
+        , indent
+        , join
+        , line
+        , nest
+        , parens
+        , pretty
+        , softline
+        , space
+        , string
+        , surround
+        )
 
 {-| Pretty printer.
 
@@ -59,7 +71,7 @@ type Normal
 
 
 
--- ==== Document constructors
+-- Document constructors -------------------------------------------------------
 
 
 {-| Creates an empty document.
@@ -132,7 +144,7 @@ nesting =
 
 
 
--- ==== Document helper functions
+-- Document helper functions ---------------------------------------------------
 
 
 {-| Places a document inside left and right book ends.
@@ -213,7 +225,7 @@ indent spaces doc =
 
 
 
--- ==== Pretty printing
+-- Pretty printing -------------------------------------------------------------
 
 
 {-| Pretty prints a document trying to fit it as best as possible to the specified
@@ -225,7 +237,7 @@ pretty w doc =
 
 
 
--- ==== Internals
+-- Internals -------------------------------------------------------------------
 
 
 flatten : Doc -> Doc

--- a/src/Pretty.elm
+++ b/src/Pretty.elm
@@ -12,13 +12,16 @@ module Pretty
         , indent
         , join
         , line
+        , lines
         , nest
         , parens
         , pretty
         , softline
+        , softlines
         , space
         , string
         , surround
+        , words
         )
 
 {-| Pretty printer.
@@ -31,7 +34,7 @@ Functions for building pieces of documents from string data.
 
 Functions for joining documents together
 
-@docs append, a, join
+@docs append, a, join, lines, softlines, words
 
 Functions for fitting documents onto lines as space allows.
 
@@ -190,6 +193,52 @@ join : Doc -> List Doc -> Doc
 join sep docs =
     List.intersperse sep docs
         |> List.foldr append empty
+
+
+{-| Concatenate a list of documents together interspersed with lines.
+Very convenient when laying out lines after another:
+
+    lines
+      [ string "Heading"
+      , empty
+      , words [string "First", string "paragraph"]
+      ...
+      ]
+
+    ==
+
+    string "Heading"
+      |> a line
+      |> a line
+      |> a (string "First")
+      |> a space
+      |> a (string "paragraph")
+      ...
+
+See also `words`.
+
+-}
+lines : List Doc -> Doc
+lines =
+    join line
+
+
+{-| Like `lines` but uses `softline` instaed.
+-}
+softlines : List Doc -> Doc
+softlines =
+    join softline
+
+
+{-| Concatenate a list of documents together interspersed with spaces.
+Very convenient when laying out words after another.
+
+See also `lines`.
+
+-}
+words : List Doc -> Doc
+words =
+    join space
 
 
 {-| Creates a document consisting of a single space.

--- a/src/Pretty.elm
+++ b/src/Pretty.elm
@@ -5,6 +5,7 @@ module Pretty
         , align
         , append
         , braces
+        , brackets
         , char
         , empty
         , fold
@@ -47,7 +48,7 @@ Functions for indenting and alinging documents.
 
 Functions for putting brackets around documents.
 
-@docs surround, parens, braces
+@docs surround, parens, braces, brackets
 
 Functions for pretty printing documents.
 
@@ -271,6 +272,13 @@ parens doc =
 braces : Doc -> Doc
 braces doc =
     surround (char '{') (char '}') doc
+
+
+{-| Wraps a document in brackets.
+-}
+brackets : Doc -> Doc
+brackets =
+    surround (char '[') (char ']')
 
 
 {-| Adds an indent of the current column position to all line breaks in the document.

--- a/src/Pretty.elm
+++ b/src/Pretty.elm
@@ -30,27 +30,33 @@ module Pretty
 
 @docs Doc
 
-Functions for building pieces of documents from string data.
+
+# Building documents from string data
 
 @docs empty, space, string, char
 
-Functions for joining documents together
+
+# Joining documents together
 
 @docs append, a, join, lines, softlines, words, fold
 
-Functions for fitting documents onto lines as space allows.
+
+# Fitting documents onto lines
 
 @docs group, line, softline
 
-Functions for indenting and alinging documents.
+
+# Indenting and alinging documents
 
 @docs align, nest, hang, indent
 
-Functions for putting brackets around documents.
+
+# Putting things around documents
 
 @docs surround, parens, braces, brackets
 
-Functions for pretty printing documents.
+
+# Pretty printing documents
 
 @docs pretty
 


### PR DESCRIPTION
This PR adds some convenience functions to build documents. Now that custom operators are removed from Elm 0.19, we cannot write pretty printers in this way any more:

```elm
    string "Heading"
      |+ line
      |+ line
      |+ string "First"
      |+ space
      |+ string "paragraph"
      ...
```

A first addition is the `a` function, which appends two documents together like the good old `(|+)` did:

```elm
    string "Heading"
      |> a line
      |> a line
      |> a (string "First")
      |> a space
      |> a (string "paragraph")
      ...
```

Even better, this is writeable using lists of lines and words. We get an interface akin Elm's Html module:

```elm
    lines
      [ string "Heading"
      , empty
      , words [string "First", string "paragraph"]
      ...
      ]
```

`words == join space` and `lines == join line`. The function `semilines` complement these two helpers.

Last but not least, this PR adds `fold` to easily fold over lists containing documents.

What do you think of these changes?